### PR TITLE
Add action tree output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: olm-bundle action
+      id: bundle
       uses: ./ # Uses the action in the root directory.
       with:
         manifestsDir: testdata/bundle/manifests
         outputDir: testdata/memcached/0.0.2
         channels: stable,beta
         package: memcached
+    - name: Tree output
+      run: echo "Tree ${{ steps.bundle.outputs.tree }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,4 @@ jobs:
         channels: stable,beta
         package: memcached
     - name: Tree output
-      run: echo "Tree ${{ steps.bundle.outputs.tree }}"
+      run: echo "${{ steps.bundle.outputs.tree }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,5 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install tree
+        run: sudo apt-get install tree -y
       - name: run test.sh
         run: ./test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 COPY generate.sh /generate.sh
 # COPY bin/opm /usr/local/bin
-RUN apt-get update && apt-get install git curl -y
+RUN apt-get update && apt-get install git curl tree -y
 # Add temporary build fix.
 # TODO: Use multistate build.
 RUN curl -Lo /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/download/v1.14.2/linux-amd64-opm && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 COPY generate.sh /generate.sh
 # COPY bin/opm /usr/local/bin
-RUN apt-get update && apt-get install git curl -y
+RUN apt-get update && apt-get install git curl tree -y
 # Add temporary build fix.
 # TODO: Use multistate build.
 RUN curl -Lo /usr/local/bin/opm https://github.com/operator-framework/operator-registry/releases/download/v1.14.2/linux-amd64-opm && \

--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: olm-bundle action
+        id: bundle
         uses: darkowlzz/olm-bundle@master
         with:
           manifestsDir: bundle/manifests
           outputDir: my-operator/${{ github.event.inputs.version }}
           channels: stable,beta
           package: my-operator
+      - name: bundle tree output
+        run: echo "${{ steps.bundle.outputs.tree }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.4.0
 ```
@@ -71,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: olm-bundle action
+        id: bundle
         uses: darkowlzz/olm-bundle@master
         with:
           outputDir: my-operator/${{ github.event.inputs.version }}
@@ -79,6 +83,8 @@ jobs:
           operatorRepo: https://github.com/example/someoperator
           operatorBranch: devel
           operatorManifestsDir: bundle/manifests
+      - name: bundle tree output
+        run: echo "${{ steps.bundle.outputs.tree }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.4.0
 ```
@@ -98,6 +104,33 @@ create a pull request with the changes.
 | `operatorRepo` | Operator git repo that contains the OLM manifests. | `https://github.com/example/my-operator` |
 | `operatorBranch` | Operator git repo branch. | `devel` |
 | `operatorManifestsDir` | Manifests dir in the operator git repo. | `bundle/manifests` |
+
+## Action outputs
+
+### `tree`
+
+Tree view of the bundle directory after the changes:
+
+```console
+testdata/memcached
+|-- 0.0.1
+|   |-- manifests
+|   |   |-- cache.example.com_memcachedpeers.yaml
+|   |   |-- cache.example.com_memcacheds.yaml
+|   |   +-- memcached-operator.clusterserviceversion.yaml
+|   +-- metadata
+|       +-- annotations.yaml
+|-- 0.0.2
+|   |-- manifests
+|   |   |-- cache.example.com_memcachedpeers.yaml
+|   |   |-- cache.example.com_memcacheds.yaml
+|   |   +-- memcached-operator.clusterserviceversion.yaml
+|   +-- metadata
+|       +-- annotations.yaml
++-- bundle-0.0.2.Dockerfile
+
+6 directories, 9 files
+```
 
 ## Using without github actions
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Operator git repo branch.'
   operatorManifestsDir:
     description: 'Manifests dir in the operator git repo.'
+outputs:
+  tree:
+    description: Tree output of the bundle.
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/generate.sh
+++ b/generate.sh
@@ -116,6 +116,7 @@ pushd $BUNDLE_DIR
 	echo "Renaming bundle.Dockerfile to $DOCKERFILE_PATH"
 	mv bundle.Dockerfile $DOCKERFILE_PATH
 popd
+echo "::set-output name=tree::$(tree $BUNDLE_DIR)"
 
 # Cleanup.
 if [ "$CLEANUP" = true ]; then

--- a/generate.sh
+++ b/generate.sh
@@ -116,7 +116,19 @@ pushd $BUNDLE_DIR
 	echo "Renaming bundle.Dockerfile to $DOCKERFILE_PATH"
 	mv bundle.Dockerfile $DOCKERFILE_PATH
 popd
-echo "::set-output name=tree::$(tree $BUNDLE_DIR)"
+
+# Print tree output as the action output.
+# NOTE: tree output includes backtick which causes error when printed using
+# echo. To avoid unexpected errors due to backticks, replace backtick and
+# similar special symbols with alternatives.
+t=$(tree $BUNDLE_DIR | sed 's/├/\+/g; s/─/-/g; s/└/\\/g; s/`/+/g')
+# NOTE: Github action truncates multi-line outputs. Escape the newline
+# characters.
+# Refer: https://github.community/t/set-output-truncates-multiline-strings/16852/3
+t="${t//'%'/'%25'}"
+t="${t//$'\n'/'%0A'}"
+t="${t//$'\r'/'%0D'}"
+echo -e "::set-output name=tree::$t"
 
 # Cleanup.
 if [ "$CLEANUP" = true ]; then


### PR DESCRIPTION
Result of `echo "${{ steps.bundle.outputs.tree }}"` in workflow test:
```console
testdata/memcached
|-- 0.0.1
|   |-- manifests
|   |   |-- cache.example.com_memcachedpeers.yaml
|   |   |-- cache.example.com_memcacheds.yaml
|   |   +-- memcached-operator.clusterserviceversion.yaml
|   +-- metadata
|       +-- annotations.yaml
|-- 0.0.2
|   |-- manifests
|   |   |-- cache.example.com_memcachedpeers.yaml
|   |   |-- cache.example.com_memcacheds.yaml
|   |   +-- memcached-operator.clusterserviceversion.yaml
|   +-- metadata
|       +-- annotations.yaml
+-- bundle-0.0.2.Dockerfile

6 directories, 9 files

```